### PR TITLE
Fix ncurses probe when using gcc 14.x

### DIFF
--- a/scripts/kconfig/lxdialog/check-lxdialog.sh
+++ b/scripts/kconfig/lxdialog/check-lxdialog.sh
@@ -40,7 +40,7 @@ trap "rm -f $tmp" 0 1 2 3 15
 check() {
         $cc -xc - -o $tmp 2>/dev/null <<'EOF'
 #include CURSES_LOC
-main() {}
+int main() {}
 EOF
 	if [ $? != 0 ]; then
 	    echo " *** Unable to find the ncurses libraries or the"       1>&2


### PR DESCRIPTION
It seems that gcc 14.2.1 fails with a hard error if main() does not have an int return type. This causes a hard error when probing for ncurses. Adding the return type fixes "make menuconfig" with host gcc 14.2.1 on
Fedora 40.