### PR TITLE
Text and comment typo corrections

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -255,7 +255,7 @@ root tree.
 ## Conclusion
 
 I understand these guidelines might seem extremely severe, potentially starving this
-project from talents, but they are here to garantee error-free software.
+project from talents, but they are here to guarantee error-free software.
 
 This is extremely important in safety critical applications for which this RTOS
 has been designed for in the first place.

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ at the following address: https://jnaulet.github.io/OpenPicoRTOS
 
 On every new cycle (tick), picoRTOS stops the execution of the current task and runs the highest
 priority task available.   
-A few criterias make a task available for scheduling, it has to be:
+A few criteria make a task available for scheduling, it has to be:
   - Ready (aka not sleeping/busy)
   - The tick modulo has to match the task sub-priority (see shared priorities)
   - In case of SMP, the task core mask has to match the current running core

--- a/README.md
+++ b/README.md
@@ -320,7 +320,7 @@ Basic demo code is provided for the following boards:
   - WCH CH32V003F4P6 eval board (staging)
 
 A portability demo is available in demo/amigaball-lcd and works with the
-follwing boards (+0.96" LCD):
+following boards (+0.96" LCD):
   - Adafruit ItsyBitsy M4 Express
   - Sipeed Longan Nano
   - Texas Instruments Launchxl-f28379d

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -281,7 +281,7 @@ Support has been added for the following architectures:
 This support is incomplete as far as the MIPS is concerned (no support for FPU or DSP yet).
 This is on purpose, as the split between architecture ankd BSP is not completely decided yet.
 
-The follwing devices are now at least partially supported:
+The following devices are now at least partially supported:
   - Atmel SAMD5x/E5x
   - Atmel TinyAVR ATtiny1607
   - PIC32MZ-EF

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -167,7 +167,7 @@ Some refactoring has been done on the ARM linker files, but it's still not 100% 
 ### What's new ?
 
 Mostly, the AmigaBall LCD demo, courtesy of slmisc on github.
-This demo has allwoed to put a series of board to a real test & imporve on the DMA for most of
+This demo has allowed to put a series of board to a real test & imporve on the DMA for most of
 them (except c2000, which is a pain anyway).
 
 A more satsifying way to manage caches has been found, hopefully.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -172,7 +172,7 @@ them (except c2000, which is a pain anyway).
 
 A more satisfying way to manage caches has been found, hopefully.
 
-PowerPC plaftorms have been added to staging and deserve a huge amount of testing.
+PowerPC platforms have been added to staging and deserve a huge amount of testing.
 
 ## picoRTOS v1.8.2
 ### What's new ?

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -39,7 +39,7 @@ Minor update, support for new architecture:
     - STM8: support for STM8Sx003
     - STM8S minimal drivers (clock, mux, gpio) + demo, staging
 
-A few fixes have been made to the build system, mainly to accomodate for newer versions of
+A few fixes have been made to the build system, mainly to accommodate for newer versions of
 the gcc compiler, thanks to David J. Fiddes
 
 ATTiny414 machine has been added, courtesy of Platima.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -55,7 +55,7 @@ Major update, experimental support for NXP HC(S)08 architecture.
 Added a perl preprocessor to generate the .S files from C header file on SDCC-related builds.   
 Which leads to minor updates to 8051 port, as .inc files were not needed anymore.
 
-A few drivers have been developped for the S08PTxx series to allow tests in staging directory.
+A few drivers have been developed for the S08PTxx series to allow tests in staging directory.
 
 ## picoRTOS v1.9.7
 ### What's new ?

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -145,7 +145,7 @@ OpenPicoRTOS is now more than an OS. It is an OS AND a build system AND a code c
 Migrating to OpenPicoRTOS has been made easier than ever (hopefully).
 
 Some changes have been made to the port API & the main API, especially regarding asserts, that have been
-made ISO-C compliant to accomodate for the now default gcc -pedantic mode.
+made ISO-C compliant to accommodate for the now default gcc -pedantic mode.
 
 Cross-dependencies between the ports and the schedulers have been totally removed.
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -167,7 +167,7 @@ Some refactoring has been done on the ARM linker files, but it's still not 100% 
 ### What's new ?
 
 Mostly, the AmigaBall LCD demo, courtesy of slmisc on github.
-This demo has allowed to put a series of board to a real test & imporve on the DMA for most of
+This demo has allowed to put a series of board to a real test & improve on the DMA for most of
 them (except c2000, which is a pain anyway).
 
 A more satsifying way to manage caches has been found, hopefully.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -312,7 +312,7 @@ code-level HAL.
 ## picoRTOS v1.5.4
 ### What's new ?
 
-picoRTOS is back ! Version 1.5.3 has seen the project being retired for professionnal use, so this
+picoRTOS is back ! Version 1.5.3 has seen the project being retired for professional use, so this
 one is a brand new architecture that has been re-written from the ground up.
 
 Unfortunately older users of picoRTOS on PowerPC and C2000 cannot update because despite similar

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -170,7 +170,7 @@ Mostly, the AmigaBall LCD demo, courtesy of slmisc on github.
 This demo has allowed to put a series of board to a real test & improve on the DMA for most of
 them (except c2000, which is a pain anyway).
 
-A more satsifying way to manage caches has been found, hopefully.
+A more satisfying way to manage caches has been found, hopefully.
 
 PowerPC plaftorms have been added to staging and deserve a huge amount of testing.
 

--- a/demo/curiosity-2.0-pic32mz-ef/README.md
+++ b/demo/curiosity-2.0-pic32mz-ef/README.md
@@ -28,7 +28,7 @@ info from the make command into the configurations.xml file of the project.
 
 It would be nicer to completely generate it but i leave that for another day.
 
-Quit MPLABX, re-open it, right-click the project and at XC32 (Global Options), sleect "Override default device support: Compiler location".
+Quit MPLABX, re-open it, right-click the project and at XC32 (Global Options), select "Override default device support: Compiler location".
 
 Then, in xc32-ld, menu "Libraries", select "Exclude standard libraries" & "Do no link crt0 startup code".
 


### PR DESCRIPTION
Improved spelling and grammar across project narrative elements.

### Edited areas:
- `CONTRIBUTING.md`, line 258: `garantee` → `guarantee`
- `README.md`, line 192: `criterias` → `criteria`
- `README.md`, line 323: `follwing` → `following`
- `RELEASE_NOTES.md`, line 42: `accomodate` → `accommodate`
- `RELEASE_NOTES.md`, line 58: `developped` → `developed`
- `RELEASE_NOTES.md`, line 148: `accomodate` → `accommodate`
- `RELEASE_NOTES.md`, line 170: `allwoed` → `allowed`
- `RELEASE_NOTES.md`, line 170: `imporve` → `improve`
- `RELEASE_NOTES.md`, line 173: `satsifying` → `satisfying`
- `RELEASE_NOTES.md`, line 175: `plaftorms` → `platforms`
- `RELEASE_NOTES.md`, line 284: `follwing` → `following`
- `RELEASE_NOTES.md`, line 315: `professionnal` → `professional`
- `demo/curiosity-2.0-pic32mz-ef/README.md`, line 31: `sleect` → `select`

These are non-functional edits only.